### PR TITLE
chore: update PNPM version in cleanup-preview workflow

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v2
         with:
-          version: 2.2.2
+          version: 10.6.5
 
       - name: Setup Surge
         run: |


### PR DESCRIPTION
- Upgraded the PNPM version from 2.2.2 to 10.6.5 in the cleanup-preview.yml workflow to ensure compatibility with recent features and improvements.
- This change aims to enhance dependency management and align with the latest updates in the project's workflow.

## Summary by Sourcery

Chores:
- Upgrade the PNPM version from 2.2.2 to 10.6.5 in the cleanup-preview.yml workflow.