### PR TITLE
chore: specify runner for fail-if-no-token job in cleanup-preview wor…

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -22,6 +22,7 @@ jobs:
   fail-if-no-token:
     needs: check-secrets
     if: needs.check-secrets.outputs.has_token == 'false'
+    runs-on: ubuntu-latest
     steps:
       - name: Fail workflow
         run: |


### PR DESCRIPTION
…kflow

- Added 'runs-on: ubuntu-latest' to the fail-if-no-token job in the cleanup-preview.yml workflow to ensure it runs on the latest Ubuntu environment.
- This change improves the consistency and reliability of the workflow execution.

## Summary by Sourcery

CI:
- Specify the runner for the fail-if-no-token job.