### PR TITLE
Feature/031

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -4,16 +4,16 @@ on:
   push:
     branches:
       - main
-  # Permite ejecutar manualmente el workflow para reutilizar el caché
+  # Allow manual execution of the workflow to reuse cache
   workflow_dispatch:
     inputs:
       force_build:
-        description: 'Forzar nueva build ignorando caché'
+        description: 'Force new build ignoring cache'
         required: false
         type: boolean
         default: false
 
-# Configuración para intentar reutilizar el caché entre ejecuciones
+# Configuration to try to reuse cache between executions
 concurrency:
   group: production-deployment-${{ github.ref_name }}
   cancel-in-progress: false
@@ -56,17 +56,17 @@ jobs:
         with:
           path: dist
 
-      # Configuración completa para GitHub Pages
+      # Complete configuration for GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
-        # Descomenta la siguiente línea y configura el permiso si prefieres usar este método
+        # Uncomment the following line and configure permissions if you prefer to use this method
         # uses: JamesIves/github-pages-deploy-action@v4
         # with:
         #   folder: dist
         #   branch: gh-pages
-        # O usa el método nativo de GitHub Pages (requiere configuración adicional)
+        # Or use GitHub Pages native method (requires additional configuration)
         run: |
-          echo "Despliegue completado a GitHub Pages"
+          echo "Deployment completed to GitHub Pages"
           echo "URL: https://$(echo ${{ github.repository }} | cut -d'/' -f2).github.io/"
 
       - name: Create deployment summary

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
     inputs:
       force_build:
-        description: 'Force new build ignoring cache'
+        description: 'Force new build ignoring cache (use when troubleshooting or when you need a guaranteed fresh build)'
         required: false
         type: boolean
         default: false
@@ -22,7 +22,7 @@ jobs:
   build:
     uses: ./.github/workflows/shared-build.yml
     with:
-      node_version: '23'
+      node_version: 23
       force_build: ${{ inputs.force_build }}
 
   deploy:

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -28,16 +28,16 @@ jobs:
         with:
           fetch-depth: 0  # Fetch all history to improve cache detection
 
-      # Determinar si se ha modificado el contenido desde la última compilación
+      # Check if content has been modified since the last build
       - name: Check for content changes
         id: check_changes
         run: |
           echo "Checking for content changes..."
           
-          # Por defecto, asumir que hay cambios
+          # Default assumption: changes exist
           CONTENT_CHANGED=true
           
-          # Solo verificar cambios si es un push o PR
+          # Only check for changes if it's a push or PR event
           if [[ "${{ github.event_name }}" == "push" || "${{ github.event_name }}" == "pull_request" ]]; then
             if git diff --name-only HEAD^ HEAD | grep -q "^src/"; then
               echo "Content changes detected in src/ directory"
@@ -50,7 +50,7 @@ jobs:
             echo "Event type is not push or PR, assuming content changed"
           fi
           
-          # Guardar resultado y mostrarlo
+          # Save and display result
           echo "content_changed=$CONTENT_CHANGED" >> $GITHUB_OUTPUT
           echo "Content changed: $CONTENT_CHANGED"
           echo "Event: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
@@ -68,7 +68,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: '**/pnpm-lock.yaml'
 
-      # Estrategia de caché para Vite
+      # Caching strategy for Vite
       - name: Cache .vite
         uses: actions/cache@v4
         with:
@@ -78,7 +78,7 @@ jobs:
             ${{ runner.os }}-vite-${{ hashFiles('pnpm-lock.yaml') }}-
             ${{ runner.os }}-vite-
 
-      # Cache para la build de Astro - versión mejorada por rama
+      # Cache for Astro build - branch-specific version
       - name: Check build cache
         id: build_cache
         uses: actions/cache@v4
@@ -94,16 +94,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Determinar si necesitamos construir el sitio
+      # Determine if we need to build the site
       - name: Determine if build is needed
         id: need_build
         run: |
-          # Inicializar variables
+          # Initialize variables
           FORCE_BUILD="${{ inputs.force_build }}"
           CACHE_HIT="${{ steps.build_cache.outputs.cache-hit }}"
           CONTENT_CHANGED="${{ steps.check_changes.outputs.content_changed }}"
           
-          # Determinar si se necesita construir
+          # Determine if build is needed
           if [[ "$FORCE_BUILD" == "true" ]]; then
             echo "Building because force_build is true"
             SHOULD_BUILD=true
@@ -118,31 +118,31 @@ jobs:
             SHOULD_BUILD=false
           fi
           
-          # Guardar resultado
+          # Save result
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
           
-          # Registro detallado para diagnóstico
+          # Detailed logging for diagnostics
           echo "Build decision:" >> $GITHUB_STEP_SUMMARY
           echo "- Force build: $FORCE_BUILD" >> $GITHUB_STEP_SUMMARY
           echo "- Cache hit: $CACHE_HIT" >> $GITHUB_STEP_SUMMARY
           echo "- Content changed: $CONTENT_CHANGED" >> $GITHUB_STEP_SUMMARY
           echo "- Will build: $SHOULD_BUILD" >> $GITHUB_STEP_SUMMARY
 
-      # Solo construir si es necesario
+      # Only build if necessary
       - name: Build site
         if: steps.need_build.outputs.should_build == 'true'
         run: pnpm run build
 
-      # Sube el artefacto siempre
+      # Always upload the artifact
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
           name: build
           path: dist/
           retention-days: 1
-          compression-level: 9 # Máxima compresión para reducir tamaño
+          compression-level: 9 # Maximum compression to reduce size
 
-      # Información detallada de build para debugging
+      # Detailed build info for debugging
       - name: Save build info
         run: |
           mkdir -p build-info

--- a/.github/workflows/shared-build.yml
+++ b/.github/workflows/shared-build.yml
@@ -11,6 +11,7 @@ on:
         required: false
         type: boolean
         default: false
+        description: "When set to true, will always perform a new build regardless of cache status or content changes. Useful for troubleshooting or ensuring a clean build."
     outputs:
       cache_hit:
         description: "Indicates if there was a cache hit on the build"
@@ -103,7 +104,10 @@ jobs:
           CACHE_HIT="${{ steps.build_cache.outputs.cache-hit }}"
           CONTENT_CHANGED="${{ steps.check_changes.outputs.content_changed }}"
           
-          # Determine if build is needed
+          # Determine if build is needed based on three criteria:
+          # 1. force_build: User explicitly requested a new build
+          # 2. cache_hit: No previous build found in cache
+          # 3. content_changed: Source files have been modified
           if [[ "$FORCE_BUILD" == "true" ]]; then
             echo "Building because force_build is true"
             SHOULD_BUILD=true


### PR DESCRIPTION
## Summary by Sourcery

Adds a force build option to the shared build workflow, allowing users to bypass the cache and ensure a fresh build. Updates the deploy-production workflow to include the force build option.

CI:
- Adds a force_build input to the shared build workflow to force a new build.
- Updates the deploy-production workflow to include the force_build input, allowing manual triggering of a fresh build.