### PR TITLE
chore: update deploy-production workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -18,6 +18,17 @@ concurrency:
   group: production-deployment-${{ github.ref_name }}
   cancel-in-progress: false
 
+# Add permissions required for GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Environment configuration for GitHub Pages
+environment:
+  name: github-pages
+  url: ${{ steps.deployment.outputs.page_url }}
+
 jobs:
   build:
     uses: ./.github/workflows/shared-build.yml
@@ -56,18 +67,9 @@ jobs:
         with:
           path: dist
 
-      # Complete configuration for GitHub Pages
       - name: Deploy to GitHub Pages
         id: deployment
-        # Uncomment the following line and configure permissions if you prefer to use this method
-        # uses: JamesIves/github-pages-deploy-action@v4
-        # with:
-        #   folder: dist
-        #   branch: gh-pages
-        # Or use GitHub Pages native method (requires additional configuration)
-        run: |
-          echo "Deployment completed to GitHub Pages"
-          echo "URL: https://$(echo ${{ github.repository }} | cut -d'/' -f2).github.io/"
+        uses: actions/deploy-pages@v4
 
       - name: Create deployment summary
         run: |
@@ -79,3 +81,4 @@ jobs:
           echo "Deployment timestamp: $(date)" >> $GITHUB_STEP_SUMMARY
           echo "Repository: ${{ github.repository }}" >> $GITHUB_STEP_SUMMARY
           echo "Branch: ${{ github.ref_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "Deployment URL: ${{ steps.deployment.outputs.page_url }}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Added permissions for GitHub Pages deployment, including read access to contents and write access to pages and id-token.
- Configured environment settings for GitHub Pages, specifying the deployment URL.
- Updated the deployment step to use the actions/deploy-pages@v4 action for improved deployment handling.
- Enhanced the deployment summary to include the deployment URL for better tracking.

## Summary by Sourcery

Update the deploy-production workflow to use the actions/deploy-pages@v4 action for deploying to GitHub Pages. This includes setting the necessary permissions and environment configurations for GitHub Pages, and updating the deployment summary to include the deployment URL.

Deployment:
- Update the deployment workflow to use the actions/deploy-pages@v4 action.
- Configure environment settings for GitHub Pages, specifying the deployment URL.
- Enhance the deployment summary to include the deployment URL for better tracking.
- Add permissions for GitHub Pages deployment, including read access to contents and write access to pages and id-token.