### PR TITLE
chore: update deploy-production workflow to streamline environment co…

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -24,11 +24,6 @@ permissions:
   pages: write
   id-token: write
 
-# Environment configuration for GitHub Pages
-environment:
-  name: github-pages
-  url: ${{ steps.deployment.outputs.page_url }}
-
 jobs:
   build:
     uses: ./.github/workflows/shared-build.yml
@@ -39,6 +34,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     env:
       CACHE_HIT: ${{ needs.build.outputs.cache_hit }}
     


### PR DESCRIPTION
…nfiguration

- Moved environment configuration for GitHub Pages deployment into the deploy job for better organization.
- Removed redundant environment settings from the previous location to enhance clarity and maintainability.

## Summary by Sourcery

Move the GitHub Pages environment configuration into the deploy job within the deploy-production workflow. This change improves the organization and maintainability of the workflow by centralizing environment settings.

Chores:
- Move environment configuration for GitHub Pages deployment into the deploy job.
- Remove redundant environment settings from the previous location.